### PR TITLE
Fix invalid match index error

### DIFF
--- a/scripting/websocket.sp
+++ b/scripting/websocket.sp
@@ -737,7 +737,7 @@ public OnChildSocketReceive(Handle:socket, const String:receiveData[], const dat
 				return;
 			}
 			decl String:sKey[256];
-			if(!GetRegexSubString(g_hRegExKey, 1, sKey, sizeof(sKey)))
+			if(strlen(sProtocol) < 1 || !GetRegexSubString(g_hRegExKey, 1, sKey, sizeof(sKey)))
 			{
 				LogError("Failed to extract security key.");
 				CloseChildSocket(iIndex);

--- a/scripting/websocket.sp
+++ b/scripting/websocket.sp
@@ -737,7 +737,7 @@ public OnChildSocketReceive(Handle:socket, const String:receiveData[], const dat
 				return;
 			}
 			decl String:sKey[256];
-			if(strlen(sProtocol) < 1 || !GetRegexSubString(g_hRegExKey, 1, sKey, sizeof(sKey)))
+			if(!GetRegexSubString(g_hRegExKey, 1, sKey, sizeof(sKey)))
 			{
 				LogError("Failed to extract security key.");
 				CloseChildSocket(iIndex);
@@ -757,7 +757,7 @@ public OnChildSocketReceive(Handle:socket, const String:receiveData[], const dat
 			decl String:sProtocol[256];
 			if(iSubStrings != -1)
 			{
-				if(!GetRegexSubString(g_hRegExProtocol, 1, sProtocol, sizeof(sProtocol)))
+				if(strlen(sProtocol) < 1 || !GetRegexSubString(g_hRegExProtocol, 1, sProtocol, sizeof(sProtocol)))
 				{
 					Format(sProtocol, sizeof(sProtocol), "");
 					// It's not required to specify a subprotocol!


### PR DESCRIPTION
This fixes the following error when the `protocol` string is empty.

```
L 10/06/2018 - 12:45:53: [SM] Exception reported: Invalid match index passed.

L 10/06/2018 - 12:45:53: [SM] Blaming: websocket.smx
L 10/06/2018 - 12:45:53: [SM] Call stack trace:
L 10/06/2018 - 12:45:53: [SM]   [0] GetRegexSubString
L 10/06/2018 - 12:45:53: [SM]   [1] Line 753, C:\Users\Jannik\Documents\GitHub\sm-websocket\scripting\websocket.sp::OnChildSocketReceive
```